### PR TITLE
Fix zoom mobile sur taps rapides + nettoyer noms propres de Sutom

### DIFF
--- a/anagramme.html
+++ b/anagramme.html
@@ -96,6 +96,8 @@
             text-transform: uppercase;
             transition: transform 0.2s ease, opacity 0.2s ease, background 0.15s ease;
             user-select: none;
+            touch-action: manipulation;
+            -webkit-tap-highlight-color: transparent;
         }
 
         .tile.source {

--- a/b-ou-d.html
+++ b/b-ou-d.html
@@ -132,6 +132,8 @@
         background-color: #e9ecef;
         color: #333;
         transition: transform 0.2s, background-color 0.2s;
+        touch-action: manipulation;
+        -webkit-tap-highlight-color: transparent;
       }
 
       .choice-btn:hover {

--- a/c-doux-dur.html
+++ b/c-doux-dur.html
@@ -123,6 +123,8 @@
         background-color: #e9ecef;
         color: #333;
         transition: transform 0.2s, background-color 0.2s;
+        touch-action: manipulation;
+        -webkit-tap-highlight-color: transparent;
       }
 
       .choice-btn:hover {

--- a/demineur.html
+++ b/demineur.html
@@ -126,6 +126,8 @@
             font-size: 1em;
             line-height: 1;
             box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.12), inset 0 2px 0 rgba(255, 255, 255, 0.18);
+            touch-action: manipulation;
+            -webkit-tap-highlight-color: transparent;
         }
 
         .cell:hover:not(.revealed):not(.flagged) {

--- a/french-phonics-game.html
+++ b/french-phonics-game.html
@@ -76,6 +76,8 @@
         width: calc(50% - 5px);
         max-width: 200px;
         white-space: nowrap;
+        touch-action: manipulation;
+        -webkit-tap-highlight-color: transparent;
       }
 
       @media (max-width: 380px) {

--- a/mastermind.html
+++ b/mastermind.html
@@ -56,6 +56,8 @@
             border: 2px solid #e0e0e0;
             cursor: pointer;
             transition: all 0.2s ease;
+            touch-action: manipulation;
+            -webkit-tap-highlight-color: transparent;
         }
 
         .peg:hover {

--- a/memory.html
+++ b/memory.html
@@ -95,6 +95,8 @@
             aspect-ratio: 3 / 4;
             perspective: 600px;
             cursor: pointer;
+            touch-action: manipulation;
+            -webkit-tap-highlight-color: transparent;
         }
 
         .card-inner {

--- a/mot-le-plus-long.html
+++ b/mot-le-plus-long.html
@@ -119,6 +119,8 @@
             transition: transform 0.1s ease, opacity 0.15s ease;
             user-select: none;
             padding: 0;
+            touch-action: manipulation;
+            -webkit-tap-highlight-color: transparent;
         }
 
         .tile:hover:not(:disabled) {

--- a/mots-enfants.txt
+++ b/mots-enfants.txt
@@ -336,7 +336,6 @@ maquillage
 maquiller
 marcheur
 marge
-marseille
 marteau
 martien
 matin
@@ -350,7 +349,6 @@ merveilleux
 mesure
 mignon
 millefeuille
-mireille
 miroir
 moineau
 moitié

--- a/ou-ou-on.html
+++ b/ou-ou-on.html
@@ -134,6 +134,8 @@
         transition:
           transform 0.2s,
           background-color 0.2s;
+        touch-action: manipulation;
+        -webkit-tap-highlight-color: transparent;
       }
 
       .choice-btn:hover {

--- a/p-ou-q.html
+++ b/p-ou-q.html
@@ -134,6 +134,8 @@
         transition:
           transform 0.2s,
           background-color 0.2s;
+        touch-action: manipulation;
+        -webkit-tap-highlight-color: transparent;
       }
 
       .choice-btn:hover {

--- a/pendu.html
+++ b/pendu.html
@@ -162,6 +162,8 @@
             align-items: center;
             justify-content: center;
             padding: 0;
+            touch-action: manipulation;
+            -webkit-tap-highlight-color: transparent;
         }
 
         .key:hover:not(:disabled) {

--- a/sutom.html
+++ b/sutom.html
@@ -151,6 +151,8 @@
             cursor: pointer;
             text-transform: uppercase;
             transition: background 0.15s ease;
+            touch-action: manipulation;
+            -webkit-tap-highlight-color: transparent;
         }
 
         .key.wide {
@@ -173,6 +175,8 @@
             cursor: pointer;
             transition: all 0.3s ease;
             margin-bottom: 10px;
+            touch-action: manipulation;
+            -webkit-tap-highlight-color: transparent;
         }
 
         .btn-new {


### PR DESCRIPTION
## Résumé

- Corrige le zoom navigateur déclenché par le double-tap sur les touches du clavier ⌫ dans Sutom (et par extension sur tous les jeux à saisie rapide)
- Ajoute `touch-action: manipulation` + `-webkit-tap-highlight-color: transparent` sur : sutom, pendu, mot-le-plus-long, anagramme, mastermind, b-ou-d, p-ou-q, ou-ou-on, c-doux-dur, french-phonics, memory, demineur
- Retire `mireille` et `marseille` (noms propres) de `mots-enfants.txt` qui sert à piocher les mots mystères de Sutom

## Test plan

- [ ] Sur mobile, taper plusieurs fois rapidement sur ⌫ dans Sutom : pas de zoom
- [ ] Tap rapide sur les lettres du pendu : pas de zoom
- [ ] Tap rapide sur les tuiles de mot-le-plus-long / anagramme : pas de zoom
- [ ] Tap rapide sur les boutons de choix (b-ou-d, p-ou-q, ou-ou-on, c-doux-dur) : pas de zoom
- [ ] Tap rapide sur les cartes memory et les cases démineur : pas de zoom
- [ ] Jouer quelques parties Sutom pour confirmer qu'aucun nom propre n'est tiré


---
_Generated by [Claude Code](https://claude.ai/code/session_01YTu2NJRmgwH4gpzTzyYeaJ)_