### PR TITLE
Confettis ronds au lieu de losanges

### DIFF
--- a/confetti.js
+++ b/confetti.js
@@ -55,11 +55,7 @@ function showConfetti() {
 
     draw() {
       ctx.beginPath()
-      ctx.moveTo(this.x, this.y)
-      ctx.lineTo(this.x + this.w, this.y + this.h)
-      ctx.lineTo(this.x + this.w * 2, this.y)
-      ctx.lineTo(this.x + this.w, this.y - this.h)
-      ctx.closePath()
+      ctx.arc(this.x, this.y, this.w / 2, 0, Math.PI * 2)
       ctx.fillStyle = this.color
       ctx.fill()
     }


### PR DESCRIPTION
## Résumé

- Confettis dessinés en cercles (`arc`) au lieu de losanges (polygone 4 points)
- Affecte tous les jeux qui utilisent `confetti.js` (sutom, anagramme, lettris, pendu, etc.)


---
_Generated by [Claude Code](https://claude.ai/code/session_01YTu2NJRmgwH4gpzTzyYeaJ)_