### PR TITLE
PWA + déploiement GitHub Pages avec previews de PR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,26 +1,41 @@
-name: Deploy
+name: Deploy to GitHub Pages
 
 on:
   push:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 concurrency:
-  group: deploy
+  # Sérialise les écritures sur gh-pages entre ce déploiement et les previews
+  # de PR, sinon deux jobs peuvent se marcher dessus sur la même branche.
+  group: gh-pages
   cancel-in-progress: false
+
+# peaceiris/actions-gh-pages@v4 déclare encore Node.js 20 et le maintainer
+# n'a pas publié de v5. À partir de 2026-06-02, GitHub force Node 24 par
+# défaut ; on opt-in maintenant pour repérer une éventuelle incompatibilité.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup SSH
-        run: |
-          mkdir -p ~/.ssh
-          chmod 700 ~/.ssh
-          echo "${{ secrets.FREEBOX_SSH_KEY }}" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
-          echo "${{ secrets.FREEBOX_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
-          chmod 644 ~/.ssh/known_hosts
+      - uses: actions/checkout@v4
 
-      - name: Pull on Freebox
-        run: ssh -i ~/.ssh/id_ed25519 -o IdentitiesOnly=yes freebox@yge3sf9e.fbxos.fr -p 60337 'git -C /var/www/html/reading-practice pull --ff-only'
+      # Site statique « nobuild » : on publie le dépôt tel quel à la RACINE de
+      # la branche gh-pages. `keep_files: true` préserve le dossier `previews/`
+      # écrit par le workflow de preview, pour que les previews survivent aux
+      # déploiements de main. `exclude_assets` retire le superflu non-web.
+      - name: Publish to gh-pages (root)
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: .
+          publish_branch: gh-pages
+          keep_files: true
+          exclude_assets: ".github,.gitignore,.prettierrc,README.md,TODO.md"
+          commit_message: "deploy: main @ ${{ github.sha }}"

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,55 @@
+name: Cleanup branch preview
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: gh-pages
+  cancel-in-progress: false
+
+jobs:
+  delete-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compute preview slug
+        id: slug
+        run: |
+          raw='${{ github.head_ref }}'
+          slug=$(echo "$raw" | tr -c 'a-zA-Z0-9-' '-' | tr -s '-' | sed 's/^-\|-$//g')
+          echo "slug=$slug" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          fetch-depth: 1
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Remove preview directory
+        run: |
+          dir="previews/${{ steps.slug.outputs.slug }}"
+          if [ -d "$dir" ]; then
+            git config user.name 'github-actions[bot]'
+            git config user.email 'github-actions[bot]@users.noreply.github.com'
+            git rm -rf "$dir"
+            git commit -m "cleanup: remove preview ${{ steps.slug.outputs.slug }}"
+            git push origin gh-pages
+          else
+            echo "No preview directory at $dir, nothing to clean."
+          fi
+
+      - name: Update PR comment
+        uses: Wandalen/wretry.action@v3.8.0
+        with:
+          action: marocchino/sticky-pull-request-comment@v2
+          attempt_limit: 3
+          attempt_delay: 10000
+          with: |
+            header: preview-${{ steps.slug.outputs.slug }}
+            message: |
+              _Preview supprimée_ (PR fermée). L'URL n'est plus accessible.

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,87 @@
+name: Deploy branch preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  # Sérialise les écritures gh-pages entre toutes les previews ET le déploiement
+  # de main, sinon deux jobs peuvent se concurrencer sur la même branche.
+  group: gh-pages
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Slug = nom de branche, tout caractère non alphanumérique réduit à `-`.
+      # Ex : `claude/intelligent-mccarthy-mcYwD`
+      #   -> `claude-intelligent-mccarthy-mcYwD`
+      - name: Compute preview slug
+        id: slug
+        run: |
+          raw='${{ github.head_ref }}'
+          slug=$(echo "$raw" | tr -c 'a-zA-Z0-9-' '-' | tr -s '-' | sed 's/^-\|-$//g')
+          echo "slug=$slug" >> "$GITHUB_OUTPUT"
+
+      # Marqueur interrogeable depuis GitHub Pages une fois la build réellement
+      # servie, pour ne pas commenter la PR avant la propagation (sinon 404 ou
+      # contenu périmé au clic).
+      - name: Write deployment marker
+        run: echo "${{ github.event.pull_request.head.sha }}" > .preview-sha
+
+      # Site statique : on publie le dépôt tel quel dans previews/<slug>/.
+      # Tous les chemins de l'app sont relatifs, donc rien à réécrire pour
+      # servir sous un sous-dossier.
+      - name: Publish to gh-pages (previews/${{ steps.slug.outputs.slug }})
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: .
+          publish_branch: gh-pages
+          destination_dir: previews/${{ steps.slug.outputs.slug }}
+          keep_files: true
+          exclude_assets: ".github,.gitignore,.prettierrc,README.md,TODO.md"
+          commit_message: "preview: ${{ steps.slug.outputs.slug }} @ ${{ github.event.pull_request.head.sha }}"
+
+      - name: Wait for GitHub Pages to serve fresh preview
+        env:
+          EXPECTED_SHA: ${{ github.event.pull_request.head.sha }}
+          SLUG: ${{ steps.slug.outputs.slug }}
+        run: |
+          url="https://isc.github.io/reading-practice/previews/$SLUG/.preview-sha"
+          for i in $(seq 1 60); do
+            actual=$(curl -fsSL "$url" 2>/dev/null | tr -d '[:space:]' || true)
+            if [ "$actual" = "$EXPECTED_SHA" ]; then
+              echo "Preview live with $EXPECTED_SHA after ${i}×5s"
+              exit 0
+            fi
+            echo "Attempt $i/60: got '$actual', want '$EXPECTED_SHA'"
+            sleep 5
+          done
+          echo "::warning::Preview did not become live with the expected SHA in 5 minutes — comment posted anyway"
+
+      - name: Comment PR with preview link
+        uses: Wandalen/wretry.action@v3.8.0
+        with:
+          action: marocchino/sticky-pull-request-comment@v2
+          attempt_limit: 3
+          attempt_delay: 10000
+          with: |
+            header: preview-${{ steps.slug.outputs.slug }}
+            message: |
+              **Preview déployée** pour cette PR :
+
+              - 🎮 App : https://isc.github.io/reading-practice/previews/${{ steps.slug.outputs.slug }}/
+
+              Commit : `${{ github.event.pull_request.head.sha }}`
+              _La preview est mise à jour à chaque push et supprimée à la fermeture de la PR._

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Marzouzoute — boîte à jeux
+
+PWA (Progressive Web App) regroupant une collection de petits jeux éducatifs en
+français : lecture, orthographe, phonétique, logique et jeux de société
+(Sutom, Pendu, Démineur, Othello, Puissance 4, Dames, 2048, Memory…).
+
+Le projet est en **HTML/CSS/JS statique, sans étape de build** : chaque jeu est
+une page autonome, reliée depuis [`index.html`](index.html).
+
+## PWA
+
+- [`manifest.json`](manifest.json) — métadonnées d'installation (nom, icônes,
+  couleurs, `start_url`, `scope`).
+- [`service-worker.js`](service-worker.js) — cache hors-ligne : précache de la
+  coquille de l'app à l'installation, puis _network-first_ pour les pages et
+  _stale-while-revalidate_ pour les autres ressources. Le `CACHE_VERSION` purge
+  les anciens caches : pense à l'incrémenter quand un asset précaché change.
+
+L'app est installable depuis le navigateur (« Ajouter à l'écran d'accueil ») et
+reste utilisable hors-ligne une fois les pages visitées.
+
+## Déploiement — GitHub Pages
+
+Le site est publié sur GitHub Pages : <https://isc.github.io/reading-practice/>
+
+- **`.github/workflows/deploy.yml`** — à chaque push sur `main`, publie le dépôt
+  à la racine de la branche `gh-pages` (via `peaceiris/actions-gh-pages`).
+- **`.github/workflows/preview.yml`** — à chaque PR, déploie une preview isolée
+  sous `previews/<branche>/` et commente la PR avec le lien.
+- **`.github/workflows/preview-cleanup.yml`** — supprime la preview à la
+  fermeture de la PR.
+
+Comme tous les chemins de l'app sont relatifs, aucune réécriture n'est
+nécessaire pour servir l'app sous un sous-dossier de preview.
+
+### Activation (à faire une fois)
+
+Dans **Settings → Pages** du dépôt, choisir comme source la branche **`gh-pages`**
+(dossier `/ (root)`). La branche est créée automatiquement au premier déploiement
+sur `main`.

--- a/index.html
+++ b/index.html
@@ -1,9 +1,19 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Page d'accueil</title>
+    <meta name="theme-color" content="#4a90e2" />
+    <meta
+      name="description"
+      content="Boîte à jeux éducatifs : lecture, orthographe, logique et jeux de société."
+    />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="Marzouzoute" />
+    <link rel="icon" type="image/png" href="icon-192x192.png" />
+    <link rel="apple-touch-icon" href="icon-192x192.png" />
+    <title>Marzouzoute — Boîte à jeux</title>
     <style>
       :root {
         --primary-color: #4a90e2;
@@ -59,7 +69,7 @@
             .then((registration) => {
               console.log(
                 "Service Worker registered with scope:",
-                registration.scope
+                registration.scope,
               )
             })
             .catch((error) => {

--- a/manifest.json
+++ b/manifest.json
@@ -1,20 +1,26 @@
 {
   "name": "Marzouzoute",
   "short_name": "Marzouzoute",
+  "description": "Boîte à jeux éducatifs : lecture, orthographe, logique et jeux de société.",
+  "lang": "fr",
   "start_url": "./index.html",
+  "scope": "./",
   "display": "standalone",
-  "background_color": "#ffffff",
-  "theme_color": "#000000",
+  "orientation": "any",
+  "background_color": "#f0f2f5",
+  "theme_color": "#4a90e2",
   "icons": [
     {
       "src": "icon-192x192.png",
       "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any maskable"
     },
     {
       "src": "icon-512x512.png",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any maskable"
     }
   ]
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,101 @@
+// Service worker de la boîte à jeux « Marzouzoute ».
+//
+// Stratégie volontairement simple, sans étape de build :
+//   - on précache la coquille de l'app (index + assets partagés) à l'install ;
+//   - en navigation (pages HTML), on tente le réseau puis on retombe sur le
+//     cache pour rester utilisable hors-ligne ;
+//   - pour les autres ressources même-origine, on sert le cache en priorité et
+//     on rafraîchit en arrière-plan (stale-while-revalidate).
+//
+// Le numéro de version ci-dessous purge les anciens caches à chaque activation :
+// pense à l'incrémenter quand des assets précachés changent.
+const CACHE_VERSION = "v1"
+const CACHE_NAME = `marzouzoute-${CACHE_VERSION}`
+
+// Coquille minimale précachée. Les pages de jeux et les gros dictionnaires
+// (fr_FR.txt, mots-enfants.txt) sont mis en cache à la volée plutôt qu'ici,
+// pour ne pas plomber la première installation.
+const PRECACHE_URLS = [
+  "./",
+  "./index.html",
+  "./manifest.json",
+  "./style.css",
+  "./confetti.js",
+  "./exit-guard.js",
+  "./OpenDyslexic-Regular.woff2",
+  "./icon-192x192.png",
+  "./icon-512x512.png",
+]
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      // addAll échoue en bloc si une seule URL renvoie une erreur ; on tolère
+      // les manquants pour ne pas casser toute l'installation.
+      .then((cache) =>
+        Promise.allSettled(PRECACHE_URLS.map((url) => cache.add(url))),
+      )
+      .then(() => self.skipWaiting()),
+  )
+})
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter(
+              (key) => key.startsWith("marzouzoute-") && key !== CACHE_NAME,
+            )
+            .map((key) => caches.delete(key)),
+        ),
+      )
+      .then(() => self.clients.claim()),
+  )
+})
+
 self.addEventListener("fetch", (event) => {
+  const { request } = event
+
+  // On ne gère que les GET même-origine ; le reste passe au réseau directement.
+  if (request.method !== "GET") return
+  const url = new URL(request.url)
+  if (url.origin !== self.location.origin) return
+
+  // Navigation (pages HTML) : réseau d'abord, cache en secours hors-ligne.
+  if (request.mode === "navigate") {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          const copy = response.clone()
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, copy))
+          return response
+        })
+        .catch(() =>
+          caches
+            .match(request)
+            .then((cached) => cached || caches.match("./index.html")),
+        ),
+    )
+    return
+  }
+
+  // Autres ressources : stale-while-revalidate.
   event.respondWith(
-    fetch(event.request).catch(() => caches.match(event.request))
+    caches.match(request).then((cached) => {
+      const network = fetch(request)
+        .then((response) => {
+          if (response && response.ok) {
+            const copy = response.clone()
+            caches.open(CACHE_NAME).then((cache) => cache.put(request, copy))
+          }
+          return response
+        })
+        .catch(() => cached)
+      return cached || network
+    }),
   )
 })


### PR DESCRIPTION
Transforme la boîte à jeux en PWA installable + offline, et bascule le déploiement vers GitHub Pages avec previews par PR, sur le modèle du repo `multiplix`.

## PWA
- **`service-worker.js`** : vrai cache hors-ligne au lieu du simple fallback réseau.
  - Précache de la coquille de l'app à l'installation (index, CSS, JS partagés, polices, icônes).
  - _Network-first_ pour les pages (HTML), _stale-while-revalidate_ pour les autres ressources.
  - Purge versionnée des anciens caches via `CACHE_VERSION` ; `skipWaiting` + `clients.claim`.
  - Les gros dictionnaires (`fr_FR.txt`, `mots-enfants.txt`) sont mis en cache à la volée, pas précachés, pour ne pas plomber la 1ʳᵉ install.
- **`manifest.json`** : ajout de `scope`, `description`, `lang`, `orientation`, `theme_color`/`background_color` cohérents, icônes `maskable`.
- **`index.html`** : meta tags PWA (`theme-color`, `apple-mobile-web-app-*`, `apple-touch-icon`, titre).

## Déploiement GitHub Pages
Remplace le déploiement Freebox (SSH) par GitHub Pages. Site statique « nobuild » : tous les chemins sont relatifs, donc aucune réécriture n'est nécessaire pour servir sous un sous-dossier de preview.
- **`deploy.yml`** : push sur `main` → publie le dépôt à la racine de `gh-pages` (`peaceiris/actions-gh-pages`, `keep_files` pour préserver les previews).
- **`preview.yml`** : sur chaque PR → preview isolée sous `previews/<branche>/`, attente de propagation Pages puis commentaire sticky avec le lien.
- **`preview-cleanup.yml`** : à la fermeture de la PR → suppression de la preview.

## README
Documente le projet, la PWA et le déploiement.

## ⚠️ Étape manuelle après merge
Dans **Settings → Pages**, choisir comme source la branche **`gh-pages`** (`/ root`). Elle est créée au premier déploiement sur `main`.

> Note : les workflows `pull_request` s'exécutent depuis la version présente sur `main`. Les previews ne seront donc actives que **pour les PR ouvertes après le merge** de celle-ci.

https://claude.ai/code/session_016fGfaK9SB8mxADdnjwzeRG

---
_Generated by [Claude Code](https://claude.ai/code/session_016fGfaK9SB8mxADdnjwzeRG)_