### PR TITLE
Évite l'annulation du déploiement Pages au merge

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -8,8 +8,14 @@ permissions:
   contents: write
   pull-requests: write
 
+# Groupe DISTINCT de celui de deploy.yml / preview.yml (`gh-pages`).
+# La fermeture d'une PR (cleanup) coïncide toujours avec le merge (push sur
+# main → deploy). S'ils partageaient le même groupe, le cleanup qui arrive en
+# file supplanterait le déploiement encore en attente, et la racine du site ne
+# serait jamais publiée. On isole donc le cleanup ; la concurrence avec un push
+# peaceiris est gérée par la boucle rebase ci-dessous.
 concurrency:
-  group: gh-pages
+  group: gh-pages-cleanup
   cancel-in-progress: false
 
 jobs:
@@ -38,7 +44,18 @@ jobs:
             git config user.email 'github-actions[bot]@users.noreply.github.com'
             git rm -rf "$dir"
             git commit -m "cleanup: remove preview ${{ steps.slug.outputs.slug }}"
-            git push origin gh-pages
+            # N'étant plus sérialisé avec les pushes peaceiris (deploy/preview),
+            # on retente avec rebase si gh-pages a bougé entre-temps.
+            for i in 1 2 3 4 5; do
+              if git push origin gh-pages; then
+                exit 0
+              fi
+              echo "Push refusé (tentative $i), rebase sur gh-pages distant…"
+              git fetch origin gh-pages
+              git rebase origin/gh-pages || exit 1
+            done
+            echo "::error::Impossible de pousser le cleanup après 5 tentatives"
+            exit 1
           else
             echo "No preview directory at $dir, nothing to clean."
           fi


### PR DESCRIPTION
## Problème

Au merge de #16, le run **« Deploy to GitHub Pages » a été annulé** au bout de 2 s, donc la racine de `gh-pages` ne contient que `.nojekyll` + `previews/` — le site (index + jeux) n'est pas publié à la racine.

Cause : au merge d'une PR, deux events se déclenchent en même temps :
- `push` sur `main` → `deploy.yml`
- `pull_request: closed` → `preview-cleanup.yml`

Les deux partageaient le groupe de concurrence `gh-pages`. Avec une preview encore *in-progress* tenant le verrou, le déploiement et le cleanup se retrouvent tous deux *pending* ; GitHub ne garde qu'un seul run en file par groupe et **annule le plus ancien (le déploiement)**. C'est reproductible à **chaque** merge.

## Correctif

- `preview-cleanup.yml` passe dans un **groupe de concurrence distinct** (`gh-pages-cleanup`), pour ne plus jamais supplanter le déploiement.
- Comme le cleanup n'est plus sérialisé avec les pushes peaceiris (deploy/preview), son `git push` gagne une **boucle rebase/retry** pour gérer une éventuelle course sur `gh-pages`.

## Effet de bord utile

Merger cette PR déclenche un `deploy.yml` sur `main` qui, cette fois, **ne sera pas annulé** et publiera enfin le site à la racine de `gh-pages`.

https://claude.ai/code/session_016fGfaK9SB8mxADdnjwzeRG

---
_Generated by [Claude Code](https://claude.ai/code/session_016fGfaK9SB8mxADdnjwzeRG)_