### PR TITLE
Contribution de jeux par issue via Claude Code Action

### DIFF
--- a/.github/ISSUE_TEMPLATE/nouveau-jeu.yml
+++ b/.github/ISSUE_TEMPLATE/nouveau-jeu.yml
@@ -1,0 +1,44 @@
+name: 🎮 Nouveau jeu
+description: Proposer un nouveau jeu à ajouter à la boîte à jeux. Claude l'implémentera et ouvrira une PR.
+title: "Nouveau jeu : "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Décris le jeu que tu aimerais ajouter. Plus c'est précis, mieux Claude
+        pourra l'implémenter. Une fois l'issue créée, Claude code le jeu, ouvre
+        une pull request et te poste le lien ici. Tu pourras tester la preview et
+        demander des ajustements en commentant « @claude … » sur la PR.
+
+  - type: input
+    id: nom
+    attributes:
+      label: Nom du jeu
+      placeholder: "ex. Fracto Dingo"
+    validations:
+      required: true
+
+  - type: textarea
+    id: concept
+    attributes:
+      label: Concept et règles
+      description: En quoi consiste le jeu ? Quelles sont les règles ? Comment gagne-t-on ?
+      placeholder: "ex. Un jeu pour apprendre les fractions : on associe une fraction à la bonne part de pizza…"
+    validations:
+      required: true
+
+  - type: input
+    id: public
+    attributes:
+      label: Public visé / niveau
+      placeholder: "ex. CE2-CM1, fractions simples"
+    validations:
+      required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Inspirations, exemples, remarques
+      description: Liens, captures, jeux similaires, contraintes pédagogiques…
+    validations:
+      required: false

--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -30,7 +30,9 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Authentification via l'abonnement Claude (Pro/Max), pas de
+          # facturation API. Token généré localement par `claude setup-token`.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model claude-opus-4-8 --max-turns 40"
           prompt: |
             Tu es déclenché par la création de l'issue #${{ github.event.issue.number }}

--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -1,0 +1,63 @@
+name: Claude — issue vers PR
+
+# À la création d'une issue (par un auteur autorisé), Claude implémente le jeu
+# demandé, ouvre une PR vers main et poste le lien de la PR dans l'issue.
+# La preview de la PR est ensuite déployée par preview.yml → testable en live.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: claude-issue-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  build-game:
+    # N'agit que pour les auteurs listés dans la variable de dépôt
+    # ISSUE_BUILDER_AUTHORS (logins séparés par des virgules, sans espaces ;
+    # ex. "isc,belle-soeur"). Les virgules encadrantes évitent les correspondances
+    # partielles (ex. "isc" ne doit pas matcher "francisco").
+    if: contains(format(',{0},', vars.ISSUE_BUILDER_AUTHORS), format(',{0},', github.event.issue.user.login))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--model claude-opus-4-8 --max-turns 40"
+          prompt: |
+            Tu es déclenché par la création de l'issue #${{ github.event.issue.number }}
+            dans le dépôt ${{ github.repository }}.
+
+            Titre de l'issue : "${{ github.event.issue.title }}"
+
+            Cette issue est une demande d'ajout d'un nouveau jeu à la boîte à jeux
+            éducatifs « Marzouzoute ». Lis attentivement la description de l'issue,
+            puis :
+
+            1. Implémente le jeu demandé en respectant SCRUPULEUSEMENT les
+               conventions du fichier CLAUDE.md (un fichier HTML autonome à la
+               racine, CSS/JS en ligne, chemins relatifs uniquement, interface en
+               français, mobile-first, réutilisation des ressources partagées
+               confetti.js / exit-guard.js si pertinent).
+            2. Ajoute une carte vers ce nouveau jeu dans la grille de index.html.
+            3. Crée une nouvelle branche et ouvre une pull request vers `main`
+               avec ton implémentation. Donne à la PR un titre clair et une
+               description qui résume le jeu et fait référence à l'issue
+               (« Closes #${{ github.event.issue.number }} »).
+            4. Poste un commentaire en français sur l'issue
+               #${{ github.event.issue.number }} avec le lien vers la PR créée,
+               en invitant l'autrice à :
+                 - tester la preview (déployée automatiquement sur la PR, le lien
+                   y est posté en commentaire) ;
+                 - laisser ses retours en commentant « @claude … » directement sur
+                   la PR pour que tu fasses les ajustements.
+
+            Reste simple et ludique : le public visé est constitué d'enfants.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,36 @@
+name: Claude
+
+# Boucle de feedback : un commentaire contenant « @claude » sur une PR (ou une
+# issue) déclenche Claude, qui applique les ajustements demandés et repush sur la
+# branche de la PR (ce qui rafraîchit la preview via preview.yml).
+#
+# L'action n'agit que pour les utilisateurs ayant un accès en écriture au dépôt
+# (barrière anti-abus intégrée) — d'où l'importance d'inviter les contributrices
+# comme collaboratrices.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  claude:
+    if: |
+      github.event.comment.user.type != 'Bot' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--model claude-opus-4-8 --max-turns 30"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,5 +32,7 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Authentification via l'abonnement Claude (Pro/Max), pas de
+          # facturation API. Token généré localement par `claude setup-token`.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model claude-opus-4-8 --max-turns 30"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,102 @@
+# CLAUDE.md — conventions du projet
+
+**Marzouzoute** est une **boîte à jeux éducatifs en français** pour enfants,
+livrée comme **PWA statique, sans étape de build**. Chaque jeu est une page HTML
+autonome, reliée depuis la grille de `index.html`.
+
+Ce fichier décrit les conventions à respecter **impérativement** quand tu ajoutes
+ou modifies un jeu, pour que tout reste cohérent et fonctionne en production
+(GitHub Pages) comme dans les previews de PR.
+
+## Architecture
+
+- **Un jeu = un fichier HTML autonome** à la racine du dépôt
+  (ex. `fracto-dingo.html`). Tout le CSS et le JS du jeu vivent **en ligne**
+  dans ce fichier (`<style>` et `<script>`), comme les jeux existants
+  (`sutom.html`, `b-ou-d.html`, `2048.html`…).
+- **Pas de framework, pas de bundler, pas de CDN, pas de dépendance externe.**
+  Le HTML/CSS/JS natif suffit. Le site doit fonctionner **hors-ligne**.
+- **Chemins relatifs uniquement.** Jamais de chemin commençant par `/`.
+  C'est critique : le site est servi sous un sous-dossier
+  (`/reading-practice/`, et `/reading-practice/previews/<branche>/` pour les
+  previews). Un chemin absolu casse tout.
+
+## Squelette d'un nouveau jeu
+
+```html
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Nom du jeu</title>
+    <style>
+      /* styles du jeu */
+    </style>
+  </head>
+  <body>
+    <!-- interface du jeu -->
+    <script>
+      // logique du jeu
+    </script>
+  </body>
+</html>
+```
+
+## Style & UX
+
+- **Langue** : toute l'interface est en **français**.
+- **Couleurs** : accent principal `#4a90e2` (bleu), fond de page `#f0f2f5`.
+- **Mobile-first** : conçu d'abord pour le tactile. Grandes cibles tactiles,
+  pas de dépendance au survol. Restreins les effets de survol avec
+  `@media (hover: hover) { … }` (sinon ils « collent » sur tactile).
+- **Police** : `Arial` convient ; pour les jeux de **lecture / orthographe**,
+  privilégie la police adaptée dyslexie déjà présente :
+  ```css
+  @font-face {
+    font-family: "OpenDyslexicRegular";
+    src: url("OpenDyslexic-Regular.woff2") format("woff2");
+  }
+  ```
+- Public : enfants. Vocabulaire simple, retours visuels clairs, ton bienveillant.
+
+## Ressources partagées réutilisables (toutes en chemin relatif)
+
+- **Confettis de victoire** : ajoute `<canvas id="confetti"></canvas>` (en
+  position fixe, plein écran, `pointer-events: none`), inclus
+  `<script src="confetti.js"></script>` et appelle `showConfetti()` à la victoire.
+- **Garde anti-sortie** : `<script src="exit-guard.js"></script>` demande
+  confirmation avant de quitter une partie en cours (utile pour le geste
+  « retour » sur mobile). Optionnel : `ExitGuard.setActive(true/false)` pour
+  délimiter précisément une partie.
+- **Listes de mots** : `fetch('fr_FR.txt')` (gros dictionnaire français) ou
+  `fetch('mots-enfants.txt')` (mots adaptés aux enfants).
+
+## Brancher le jeu dans l'accueil
+
+Ajoute une carte dans la grille de `index.html` :
+
+```html
+<a class="grid-option" href="fracto-dingo.html">
+  <h3>Fracto Dingo</h3>
+</a>
+```
+
+## PWA / cache
+
+- Les nouvelles pages de jeu sont mises en cache **automatiquement** par le
+  service worker à la première visite (aucune modif de `service-worker.js`
+  nécessaire).
+- N'incrémente `CACHE_VERSION` dans `service-worker.js` **que** si tu modifies un
+  asset déjà précaché (la coquille) et veux forcer une purge immédiate.
+
+## Style de code
+
+- Prettier est configuré (`.prettierrc` : `tabWidth: 2`, pas de point-virgule).
+  Reste cohérent avec le fichier que tu édites.
+
+## Déploiement (pour info)
+
+- Push sur `main` → publication sur GitHub Pages.
+- Chaque PR → preview isolée déployée automatiquement, avec lien posté en
+  commentaire. C'est cette preview qui sert à tester un nouveau jeu avant merge.

--- a/README.md
+++ b/README.md
@@ -38,3 +38,36 @@ nécessaire pour servir l'app sous un sous-dossier de preview.
 Dans **Settings → Pages** du dépôt, choisir comme source la branche **`gh-pages`**
 (dossier `/ (root)`). La branche est créée automatiquement au premier déploiement
 sur `main`.
+
+## Contribuer un jeu via une issue (Claude)
+
+Une contributrice autorisée peut faire ajouter un jeu **sans écrire de code** :
+
+1. Elle ouvre une **issue** avec le template _« 🎮 Nouveau jeu »_ décrivant le jeu.
+2. Le workflow **`claude-issue-to-pr.yml`** déclenche Claude (modèle Opus), qui
+   implémente le jeu en suivant [`CLAUDE.md`](CLAUDE.md), ouvre une **PR** et
+   poste le lien de la PR dans l'issue.
+3. La **preview** de la PR se déploie (workflow `preview.yml`) → elle teste le jeu
+   en live.
+4. Elle laisse des retours en commentant **`@claude …`** sur la PR ; le workflow
+   **`claude.yml`** relance Claude, qui ajuste et repush (la preview se met à jour).
+5. Le mainteneur relit et merge.
+
+### Mise en place (admin, une fois)
+
+1. **Installer l'app GitHub Claude** sur le dépôt :
+   <https://github.com/apps/claude> (permissions Contents / Issues / Pull requests).
+   _Astuce : la commande `/install-github-app` dans Claude Code fait l'app + le
+   secret d'un coup._ Installer l'app (et non se reposer sur le `GITHUB_TOKEN` par
+   défaut) est nécessaire pour que les PR créées par Claude déclenchent bien les
+   previews et la CI.
+2. **Ajouter le secret** `ANTHROPIC_API_KEY`
+   (_Settings → Secrets and variables → Actions → Secrets_).
+3. **Déclarer les auteurs autorisés** dans une **variable** de dépôt
+   (_… → Actions → Variables_) : `ISSUE_BUILDER_AUTHORS` = logins GitHub séparés
+   par des virgules **sans espaces**, ex. `isc,le-handle-de-ta-belle-soeur`.
+4. **Inviter les contributrices comme collaboratrices** (accès _write_) :
+   l'action n'agit que pour les utilisateurs autorisés (barrière anti-abus).
+
+> Coûts : chaque exécution consomme des minutes GitHub Actions et des tokens API
+> (facturés sur le compte Anthropic du secret). `--max-turns` borne les boucles.

--- a/README.md
+++ b/README.md
@@ -61,13 +61,20 @@ Une contributrice autorisée peut faire ajouter un jeu **sans écrire de code** 
    secret d'un coup._ Installer l'app (et non se reposer sur le `GITHUB_TOKEN` par
    défaut) est nécessaire pour que les PR créées par Claude déclenchent bien les
    previews et la CI.
-2. **Ajouter le secret** `ANTHROPIC_API_KEY`
-   (_Settings → Secrets and variables → Actions → Secrets_).
+2. **Ajouter le secret** `CLAUDE_CODE_OAUTH_TOKEN`
+   (_Settings → Secrets and variables → Actions → Secrets_). Génère le token
+   localement avec ton abonnement **Claude Pro ou Max** :
+   ```bash
+   claude setup-token
+   ```
+   et colle la valeur dans le secret. Aucune facturation API : ça consomme ton
+   quota d'abonnement (les mêmes limites que ton usage interactif de Claude Code).
 3. **Déclarer les auteurs autorisés** dans une **variable** de dépôt
    (_… → Actions → Variables_) : `ISSUE_BUILDER_AUTHORS` = logins GitHub séparés
    par des virgules **sans espaces**, ex. `isc,le-handle-de-ta-belle-soeur`.
 4. **Inviter les contributrices comme collaboratrices** (accès _write_) :
    l'action n'agit que pour les utilisateurs autorisés (barrière anti-abus).
 
-> Coûts : chaque exécution consomme des minutes GitHub Actions et des tokens API
-> (facturés sur le compte Anthropic du secret). `--max-turns` borne les boucles.
+> Coûts : chaque exécution consomme des minutes GitHub Actions et puise dans le
+> quota de l'abonnement Claude lié au token (mêmes limites que l'usage interactif).
+> `--max-turns` borne les boucles.


### PR DESCRIPTION
Met en place la contribution de jeux **par issue**, propulsée par [Claude Code Action](https://github.com/anthropics/claude-code-action) (v1). Objectif : une contributrice (p. ex. de l'Éducation nationale) demande un jeu en langage naturel, Claude l'implémente, ouvre une PR testable, et itère sur ses retours — sans qu'elle écrive de code.

## Flux
1. Elle ouvre une **issue** (template _« 🎮 Nouveau jeu »_).
2. **`claude-issue-to-pr.yml`** : Claude (Opus) code le jeu selon `CLAUDE.md`, ouvre une **PR** et poste le lien dans l'issue.
3. **`preview.yml`** (existant) déploie la **preview** de la PR → test en live.
4. Elle commente **`@claude …`** sur la PR → **`claude.yml`** relance Claude qui ajuste et repush (preview rafraîchie).
5. Le mainteneur relit et merge.

## Contenu
- **`.github/workflows/claude-issue-to-pr.yml`** — déclenché sur `issues: opened`, **gaté par l'auteur** via la variable de dépôt `ISSUE_BUILDER_AUTHORS` (logins séparés par virgules, sans espaces). Modèle `claude-opus-4-8`.
- **`.github/workflows/claude.yml`** — répond aux commentaires `@claude` sur PR/issues (boucle de feedback). Ignore les bots, exige `@claude`.
- **`CLAUDE.md`** — conventions du projet (un jeu = 1 HTML autonome, chemins relatifs, FR, mobile-first, ressources partagées…) pour des jeux cohérents.
- **Template d'issue** « Nouveau jeu ».
- **README** — flux + checklist de mise en place.

## ⚠️ À faire côté admin (je ne peux pas le faire)
1. Installer l'app GitHub **Claude** : https://github.com/apps/claude (ou `/install-github-app`). Indispensable pour que les PR créées par Claude déclenchent previews/CI (sinon le `GITHUB_TOKEN` par défaut ne re-déclenche pas les workflows).
2. Ajouter le secret **`ANTHROPIC_API_KEY`**.
3. Définir la variable **`ISSUE_BUILDER_AUTHORS`** = `isc,<handle-belle-soeur>`.
4. **Inviter ta belle-sœur comme collaboratrice** (write) — l'action n'agit que pour les utilisateurs autorisés.

## Notes
- Les workflows `pull_request`/`issues` ne prennent effet qu'une fois sur `main` (GitHub lit la définition depuis la branche par défaut) — donc le flux complet sera actif **après merge** de cette PR.
- Coûts : minutes Actions + tokens API (compte Anthropic du secret) ; `--max-turns` borne les boucles.

https://claude.ai/code/session_016fGfaK9SB8mxADdnjwzeRG

---
_Generated by [Claude Code](https://claude.ai/code/session_016fGfaK9SB8mxADdnjwzeRG)_