### PR TITLE
Gate les workflows Claude sur le statut collaborateur

### DIFF
--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -19,11 +19,12 @@ concurrency:
 
 jobs:
   build-game:
-    # N'agit que pour les auteurs listés dans la variable de dépôt
-    # ISSUE_BUILDER_AUTHORS (logins séparés par des virgules, sans espaces ;
-    # ex. "isc,belle-soeur"). Les virgules encadrantes évitent les correspondances
-    # partielles (ex. "isc" ne doit pas matcher "francisco").
-    if: contains(format(',{0},', vars.ISSUE_BUILDER_AUTHORS), format(',{0},', github.event.issue.user.login))
+    # N'agit que si l'autrice de l'issue est le propriétaire ou une
+    # collaboratrice du dépôt (accès write) — on s'appuie sur le statut
+    # collaborateur natif de GitHub plutôt que sur une liste à maintenir.
+    # Gate explicite (notre propre if:) pour ne pas dépendre du check interne
+    # de l'action, non garanti en mode automation (prompt fourni).
+    if: contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.issue.author_association)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,8 +21,13 @@ permissions:
 
 jobs:
   claude:
+    # Commentaire d'un humain, contenant « @claude », et émis par le
+    # propriétaire ou une collaboratrice (accès write) — même barrière que le
+    # workflow issue→PR, basée sur le statut collaborateur natif.
     if: |
-      github.event.comment.user.type != 'Bot' && (
+      github.event.comment.user.type != 'Bot'
+      && contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association)
+      && (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
       )

--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ Une contributrice autorisée peut faire ajouter un jeu **sans écrire de code** 
    ```
    et colle la valeur dans le secret. Aucune facturation API : ça consomme ton
    quota d'abonnement (les mêmes limites que ton usage interactif de Claude Code).
-3. **Déclarer les auteurs autorisés** dans une **variable** de dépôt
-   (_… → Actions → Variables_) : `ISSUE_BUILDER_AUTHORS` = logins GitHub séparés
-   par des virgules **sans espaces**, ex. `isc,le-handle-de-ta-belle-soeur`.
-4. **Inviter les contributrices comme collaboratrices** (accès _write_) :
-   l'action n'agit que pour les utilisateurs autorisés (barrière anti-abus).
+3. **Inviter les contributrices comme collaboratrices** (accès _write_) :
+   _Settings → Collaborators_. C'est ce statut qui sert de barrière anti-abus —
+   les workflows ne se déclenchent que pour le propriétaire ou des collaboratrices
+   (`author_association` ∈ `OWNER` / `COLLABORATOR` / `MEMBER`). Une issue ou un
+   `@claude` d'un inconnu est ignoré.
 
 > Coûts : chaque exécution consomme des minutes GitHub Actions et puise dans le
 > quota de l'abonnement Claude lié au token (mêmes limites que l'usage interactif).


### PR DESCRIPTION
Simplifie le gating des workflows Claude (suite à #20) : on supprime la variable `ISSUE_BUILDER_AUTHORS` et on s'appuie sur le **statut collaborateur natif** de GitHub.

## Pourquoi
Le check write-access intégré à l'action est documenté pour les commentaires `@claude`, mais **pas garanti** pour le déclenchement par issue en **mode automation** (prompt fourni). On garde donc un gate **explicite** (notre propre `if:`), basé sur `author_association`, plutôt que de dépendre de la boîte noire de l'action.

## Changements
- **`claude-issue-to-pr.yml`** : `if: contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), github.event.issue.author_association)`
- **`claude.yml`** : ajoute le même check sur `github.event.comment.author_association` (en plus de `@claude` + anti-bot).
- **README** : étape « variable » retirée ; l'invitation collaboratrice devient la barrière documentée.

## Effet sur la mise en place (admin)
On passe de 4 à **3 étapes** : app `@claude`, secret `CLAUDE_CODE_OAUTH_TOKEN`, **inviter la contributrice en collaboratrice** (write). Plus de variable à maintenir. Une issue / un `@claude` d'un non-collaborateur est ignoré.

https://claude.ai/code/session_016fGfaK9SB8mxADdnjwzeRG

---
_Generated by [Claude Code](https://claude.ai/code/session_016fGfaK9SB8mxADdnjwzeRG)_