### PR TITLE
Ajoute id-token: write aux workflows Claude

### DIFF
--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -6,12 +6,16 @@ name: Claude — issue vers PR
 
 on:
   issues:
-    types: [opened]
+    types: [opened, reopened]
 
 permissions:
   contents: write
   issues: write
   pull-requests: write
+  # Requis : l'app Claude s'authentifie via OIDC (échange contre un token
+  # d'installation GitHub).
+  id-token: write
+  actions: read
 
 concurrency:
   group: claude-issue-${{ github.event.issue.number }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,10 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  # Requis : l'app Claude s'authentifie via OIDC (échange contre un token
+  # d'installation GitHub).
+  id-token: write
+  actions: read
 
 jobs:
   claude:


### PR DESCRIPTION
Corrige l'échec du workflow sur l'issue #22 : `Could not fetch an OIDC token. Did you remember to add 'id-token: write'?`

L'app Claude s'authentifie via **OIDC** (échange d'un token OIDC contre un token d'installation GitHub) → la permission **`id-token: write`** est requise et manquait.

- `id-token: write` + `actions: read` ajoutés à `claude.yml` et `claude-issue-to-pr.yml`
- `claude-issue-to-pr.yml` déclenche aussi sur `reopened` → on peut relancer une demande en **rouvrant l'issue** (pratique depuis mobile)

https://claude.ai/code/session_016fGfaK9SB8mxADdnjwzeRG

---
_Generated by [Claude Code](https://claude.ai/code/session_016fGfaK9SB8mxADdnjwzeRG)_