### PR TITLE
Autorise git/gh pour que Claude crée branches et PR

### DIFF
--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -38,7 +38,13 @@ jobs:
           # Authentification via l'abonnement Claude (Pro/Max), pas de
           # facturation API. Token généré localement par `claude setup-token`.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-opus-4-8 --max-turns 40"
+          # Par défaut l'action n'autorise que l'édition de fichiers, le git en
+          # lecture seule et les commentaires. On étend avec git/gh pour que
+          # Claude puisse créer la branche, pousser et ouvrir la PR.
+          claude_args: |
+            --model claude-opus-4-8
+            --max-turns 40
+            --allowedTools "Bash(git:*),Bash(gh:*)"
           prompt: |
             Tu es déclenché par la création de l'issue #${{ github.event.issue.number }}
             dans le dépôt ${{ github.repository }}.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,4 +44,9 @@ jobs:
           # Authentification via l'abonnement Claude (Pro/Max), pas de
           # facturation API. Token généré localement par `claude setup-token`.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-opus-4-8 --max-turns 30"
+          # git/gh autorisés pour que Claude puisse pousser ses ajustements sur
+          # la branche de la PR (et au besoin ouvrir/mettre à jour une PR).
+          claude_args: |
+            --model claude-opus-4-8
+            --max-turns 30
+            --allowedTools "Bash(git:*),Bash(gh:*)"


### PR DESCRIPTION
Deuxième correctif du flux issue→PR (suite à #23). Sur l'issue #22, le run a réussi côté action mais avec **17 refus de permission** et **aucune PR** : par défaut, claude-code-action n'autorise que l'édition de fichiers, le git en lecture seule et les commentaires — pas la création de branche / push / ouverture de PR.

## Correctif
On étend les outils autorisés (ça **s'ajoute** aux outils de base, sans les remplacer) :
```yaml
--allowedTools "Bash(git:*),Bash(gh:*)"
```
- `claude-issue-to-pr.yml` : Claude peut créer la branche, pousser, `gh pr create`.
- `claude.yml` : Claude peut pousser ses ajustements sur la branche de la PR.

À merger pour réactiver le test (puis rouvrir l'issue #22).

https://claude.ai/code/session_016fGfaK9SB8mxADdnjwzeRG

---
_Generated by [Claude Code](https://claude.ai/code/session_016fGfaK9SB8mxADdnjwzeRG)_