### PR TITLE
Autorise Bash complet dans les workflows Claude

### DIFF
--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -38,13 +38,13 @@ jobs:
           # Authentification via l'abonnement Claude (Pro/Max), pas de
           # facturation API. Token généré localement par `claude setup-token`.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Par défaut l'action n'autorise que l'édition de fichiers, le git en
-          # lecture seule et les commentaires. On étend avec git/gh pour que
-          # Claude puisse créer la branche, pousser et ouvrir la PR.
+          # Bash complet autorisé : le runner est un container éphémère isolé et
+          # l'auteur de l'issue est un collaborateur de confiance (gate
+          # author_association). Ça évite les refus sur git/gh/npm/node/prettier…
           claude_args: |
             --model claude-opus-4-8
             --max-turns 40
-            --allowedTools "Bash(git:*),Bash(gh:*)"
+            --allowedTools "Bash"
           prompt: |
             Tu es déclenché par la création de l'issue #${{ github.event.issue.number }}
             dans le dépôt ${{ github.repository }}.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,9 +44,9 @@ jobs:
           # Authentification via l'abonnement Claude (Pro/Max), pas de
           # facturation API. Token généré localement par `claude setup-token`.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # git/gh autorisés pour que Claude puisse pousser ses ajustements sur
-          # la branche de la PR (et au besoin ouvrir/mettre à jour une PR).
+          # Bash complet autorisé (runner éphémère isolé, commentateur de
+          # confiance) pour pousser les ajustements sur la branche de la PR.
           claude_args: |
             --model claude-opus-4-8
             --max-turns 30
-            --allowedTools "Bash(git:*),Bash(gh:*)"
+            --allowedTools "Bash"


### PR DESCRIPTION
Élargit `--allowedTools` de `Bash(git:*),Bash(gh:*)` à **`Bash`** (toutes commandes) sur les deux workflows Claude.

Justification : le runner GitHub-hosted est un container **éphémère et isolé** (détruit après le job), et les workflows sont gatés aux **collaborateurs/OWNER** (`author_association`) — donc auteurs de confiance, pas d'injection par un inconnu. Aucune raison de brider : ça évite de futurs refus sur `npm`, `node`, `prettier`, etc.

https://claude.ai/code/session_016fGfaK9SB8mxADdnjwzeRG

---
_Generated by [Claude Code](https://claude.ai/code/session_016fGfaK9SB8mxADdnjwzeRG)_